### PR TITLE
fixed deployment files for xf-mock

### DIFF
--- a/xf-mock/deployment/k8s.yaml
+++ b/xf-mock/deployment/k8s.yaml
@@ -36,15 +36,3 @@ spec:
     port: 10000
   selector:
     app: xf-mock
----
-apiVersion: gateway.kyma-project.io/v1alpha2
-kind: Api
-metadata:
-  labels:
-    app: xf-mock
-  name: xf-mock
-spec:
-  hostname: xf
-  service:
-    name: xf-mock
-    port: 10000

--- a/xf-mock/deployment/xf.yaml
+++ b/xf-mock/deployment/xf.yaml
@@ -44,7 +44,7 @@ metadata:
     app: xf-mock
   name: xf-mock
 spec:
-  hostname: xf
+  hostname: xf-mock
   service:
     name: xf-mock
     port: 10000

--- a/xf-mock/test.js
+++ b/xf-mock/test.js
@@ -24,7 +24,7 @@ describe('tests app', function () {
                         .expect(200, done)
                 });
             });
-            describe('GET applications', function () {
+            describe('GET applications valid', function () {
                 it('should return 200', function (done) {
                     request(app)
                         .get('/v1/applications')
@@ -35,7 +35,7 @@ describe('tests app', function () {
                         .expect(200, done)
                 });
             });
-            describe('GET applications', function () {
+            describe('GET applications invalid', function () {
                 it('should return 400', function (done) {
                     request(app)
                         .get('/v1/applications')


### PR DESCRIPTION
The deployment file xf.yaml is not working as the API resource definition requires a hostname with at least 3 characters.
So I adjusted the hostname to "xf-mock".
Furthermore, I removed the API resource definition from plain k8s deployment file