### PR TITLE
Fixes dead links and uses only kubectl

### DIFF
--- a/c4c-mock/README.md
+++ b/c4c-mock/README.md
@@ -30,7 +30,7 @@ kubectl label namespace mocks env=true
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/c4c-mock/deployment/xf.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/c4c-mock/deployment/xf.yaml -n mocks
 ```
 
 That will expose the UI and API of the mock via a `ÀPI` resource and the UI will be accessible at: https://c4c.[yourDomain]
@@ -42,7 +42,7 @@ kubectl create namespace mocks
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/c4c-mock/deployment/k8s.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/c4c-mock/deployment/k8s.yaml -n mocks
 ```
 
 That will deploy a `Service` of type ClusterIP, which need to expose manually via any Ingress type.

--- a/commerce-mock/README.md
+++ b/commerce-mock/README.md
@@ -32,7 +32,7 @@ kubectl label namespace mocks env=true
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/commerce-mock/deployment/xf.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/commerce-mock/deployment/xf.yaml -n mocks
 ```
 
 That will expose the UI and API of the mock via a `ÀPI` resource and the UI will be accessible at: https://commerce.[yourDomain]
@@ -44,7 +44,7 @@ kubectl create namespace mocks
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/commerce-mock/deployment/k8s.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/commerce-mock/deployment/k8s.yaml -n mocks
 ```
 
 That will deploy a `Service` of type ClusterIP, which need to expose manually via any Ingress type.

--- a/marketing-mock/README.md
+++ b/marketing-mock/README.md
@@ -38,7 +38,7 @@ kubectl label namespace mocks env=true
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/marketing-mock/deployment/xf.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/marketing-mock/deployment/xf.yaml -n mocks
 ```
 
 That will expose the UI and API of the mock via a `ÀPI` resource and the UI will be accessible at: https://marketing.[yourDomain]
@@ -50,7 +50,7 @@ kubectl create namespace mocks
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/marketing-mock/deployment/k8s.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/marketing-mock/deployment/k8s.yaml -n mocks
 ```
 
 That will deploy a `Service` of type ClusterIP, which need to expose manually via any Ingress type.

--- a/xf-mock/README.md
+++ b/xf-mock/README.md
@@ -31,7 +31,7 @@ kubectl label namespace mocks env=true
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/xf-mock/deployment/xf.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/xf-mock/deployment/xf.yaml -n mocks
 ```
 
 That will expose the UI and API of the mock via a `ÀPI` resource and the UI will be accessible at: https://xf.[yourDomain]
@@ -43,7 +43,7 @@ kubectl create namespace mocks
 
 and to deploy the mock
 ```bash
-curl https://github.com/SAP/xf-application-mocks/master/xf-mock/deployment/k8s.yaml | kubectl apply -n mocks -f -
+kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/xf-mock/deployment/k8s.yaml -n mocks
 ```
 
 That will deploy a `Service` of type ClusterIP, which need to expose manually via any Ingress type.


### PR DESCRIPTION
The links to the yaml files do not work. I fixed the links and I also suggest to use only kubectl instead of downloading the file and applying it.