### PR TITLE
removed istio annotations as they are not required anymore

### DIFF
--- a/c4c-mock/deployment/k8s.yaml
+++ b/c4c-mock/deployment/k8s.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: c4c-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/c4c-mock:latest

--- a/c4c-mock/deployment/xf.yaml
+++ b/c4c-mock/deployment/xf.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: c4c-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/c4c-mock:latest

--- a/commerce-mock/deployment/k8s.yaml
+++ b/commerce-mock/deployment/k8s.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: commerce-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/commerce-mock:latest

--- a/commerce-mock/deployment/xf.yaml
+++ b/commerce-mock/deployment/xf.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: commerce-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/commerce-mock:latest

--- a/marketing-mock/deployment/k8s.yaml
+++ b/marketing-mock/deployment/k8s.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: marketing-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/marketing-mock:latest

--- a/marketing-mock/deployment/xf.yaml
+++ b/marketing-mock/deployment/xf.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: marketing-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-application-mocks/marketing-mock:latest

--- a/xf-mock/deployment/k8s.yaml
+++ b/xf-mock/deployment/k8s.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: xf-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-mock:latest

--- a/xf-mock/deployment/xf.yaml
+++ b/xf-mock/deployment/xf.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: xf-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/xf-mock:latest


### PR DESCRIPTION
Istio configuration is required only for XF specific deployments. Here, an XF namespace has sidecar injection enabled on namespace already, so no need to put the annotations for any deployment.