### PR TITLE
Fix hyperlink for list of mocked APIs

### DIFF
--- a/commerce-mock/README.md
+++ b/commerce-mock/README.md
@@ -1,5 +1,5 @@
 # Commerce Mock
-The commerce mock emulates SAP Commerce Cloud. It uses the **varkes-api-server** to connect to SAP Cloud Platform Extension Factory and register the bundled commerce APIs, which are also mocked using the **varkes-openapi-mock**. For the list of mocked APIs, see [`varkes_config.js`](varkes_config.js).
+The commerce mock emulates SAP Commerce Cloud. It uses the **varkes-api-server** to connect to SAP Cloud Platform Extension Factory and register the bundled commerce APIs, which are also mocked using the **varkes-openapi-mock**. For the list of mocked APIs, see [`varkes_config.json`](varkes_config.json).
 
 ## Run locally using Docker
 


### PR DESCRIPTION
Existing hyperlink redirects to 404 page (https://github.com/SAP/xf-application-mocks/blob/master/commerce-mock/varkes_config.js). Hence updated the link to target actual file varkes_config.json.