### PR TITLE
Fix hyperlink for list of mocked APIs

### DIFF
--- a/c4c-mock/README.md
+++ b/c4c-mock/README.md
@@ -1,7 +1,7 @@
 
 # Cloud for Customer Mock
 
-This application emulates SAP Cloud for Customer. It uses the **varkes-api-server** to connect to SAP Cloud Platform Extension Factory and register the bundled ODATA APIs which are also mocked using the  **varkes-odata-mock**. For the list of mocked APIs, see [`varkes_config.js`](varkes_config.js).
+This application emulates SAP Cloud for Customer. It uses the **varkes-api-server** to connect to SAP Cloud Platform Extension Factory and register the bundled ODATA APIs which are also mocked using the  **varkes-odata-mock**. For the list of mocked APIs, see [`varkes_config.json`](varkes_config.json).
 
 ## Run locally using Docker
 


### PR DESCRIPTION
Existing hyperlink redirects to 404 page (https://github.com/SAP/xf-application-mocks/blob/master/c4c-mock/varkes_config.js). Hence updated the link to target actual file varkes_config.json.